### PR TITLE
Enum as integer SignalR

### DIFF
--- a/ChatAPI.WebAPI/Extensions/ServiceCollectionExtension.cs
+++ b/ChatAPI.WebAPI/Extensions/ServiceCollectionExtension.cs
@@ -4,7 +4,10 @@ using ChatAPI.Application.UseCases.Implementations;
 using ChatAPI.Persistence.Database;
 using ChatAPI.Persistence.Repositories;
 using ChatAPI.WebAPI.Common;
+using ChatAPI.WebAPI.Modules.MessagePackProtocol;
 using ChatAPI.WebAPI.Services.Authorization;
+using MessagePack;
+using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
@@ -130,7 +133,18 @@ namespace ChatAPI.WebAPI.Extensions
 				.AddScoped<IUserService, UserService>()
 				.AddScoped<IFriendshipService, FriendshipService>()
 				.AddSignalR()
-					.AddMessagePackProtocol()
+					.AddMessagePackProtocol(options =>
+					{
+						IFormatterResolver resolver = CompositeResolver.Create(
+							EnumAsIntegerResolver.Instance,
+							StandardResolver.Instance
+						);
+
+						options.SerializerOptions = MessagePackSerializerOptions.Standard
+							.WithResolver(resolver)
+							.WithCompression(MessagePackCompression.Lz4Block)
+							.WithSecurity(MessagePackSecurity.UntrustedData);
+					})
 				.Services;
 	}
 }

--- a/ChatAPI.WebAPI/Modules/MessagePackProtocol/EnumAsIntegerFormatter.cs
+++ b/ChatAPI.WebAPI/Modules/MessagePackProtocol/EnumAsIntegerFormatter.cs
@@ -1,0 +1,20 @@
+﻿using MessagePack;
+using MessagePack.Formatters;
+
+namespace ChatAPI.WebAPI.Modules.MessagePackProtocol
+{
+	public class EnumAsIntegerFormatter<T> : IMessagePackFormatter<T>
+	{
+		public static readonly IMessagePackFormatter<T> Instance = typeof(T).IsEnum ? new EnumAsIntegerFormatter<T>() : null;
+
+		public void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options)
+		{
+			writer.Write(Convert.ToInt32(value));
+		}
+
+		public T Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+		{
+			return (T)Enum.ToObject(typeof(T), reader.ReadInt32());
+		}
+	}
+}

--- a/ChatAPI.WebAPI/Modules/MessagePackProtocol/EnumAsIntegerResolver.cs
+++ b/ChatAPI.WebAPI/Modules/MessagePackProtocol/EnumAsIntegerResolver.cs
@@ -1,0 +1,19 @@
+﻿using ChatAPI.WebAPI.Extensions;
+using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+
+namespace ChatAPI.WebAPI.Modules.MessagePackProtocol
+{
+	public class EnumAsIntegerResolver : IFormatterResolver
+	{
+		public static readonly IFormatterResolver Instance = new EnumAsIntegerResolver();
+
+		private EnumAsIntegerResolver() { }
+
+		public IMessagePackFormatter<T> GetFormatter<T>()
+		{
+			return EnumAsIntegerFormatter<T>.Instance ?? StandardResolver.Instance.GetFormatter<T>();
+		}
+	}
+}


### PR DESCRIPTION
Created formatter and resolver to use in the  signalR message pack options in order to send enums as integers.